### PR TITLE
修复一些使用过程中发现的问题

### DIFF
--- a/packages/i18n-extract-cli/src/collector.ts
+++ b/packages/i18n-extract-cli/src/collector.ts
@@ -30,13 +30,14 @@ class Collector {
     return this.currentFilePath
   }
 
-  add(value: string, customizeKeyFn: CustomizeKey) {
-    const formattedValue = removeLineBreaksInTag(value)
-    const customizeKey = customizeKeyFn(escapeQuotes(formattedValue), this.currentFilePath) // key中不能包含回车
-    log.verbose('提取中文：', formattedValue)
-    this.keyMap[customizeKey] = formattedValue.replace('|', "{'|'}") // '|' 管道符在vue-i18n表示复数形式,需要特殊处理。见https://vue-i18n.intlify.dev/guide/essentials/pluralization.html
+  add(originalText: string, customizeKeyFn: CustomizeKey) {
+    const formattedText = removeLineBreaksInTag(originalText)
+    const translationKey = customizeKeyFn(escapeQuotes(formattedText), this.currentFilePath) // key中不能包含回车
+    log.verbose('提取中文：', formattedText)
+    this.keyMap[translationKey] = formattedText.replace('|', "{'|'}") // '|' 管道符在vue-i18n表示复数形式,需要特殊处理。见https://vue-i18n.intlify.dev/guide/essentials/pluralization.html
     this.countOfAdditions++
-    this.currentFileKeyMap[customizeKey] = formattedValue
+    this.currentFileKeyMap[translationKey] = formattedText
+    return translationKey
   }
 
   getCurrentFileKeyMap(): Record<string, string> {

--- a/packages/i18n-extract-cli/src/transformJs.ts
+++ b/packages/i18n-extract-cli/src/transformJs.ts
@@ -366,6 +366,44 @@ function transformJs(code: string, options: transformOptions): GeneratorResult {
           // 允许往react函数组件中加入自定义代码
           insertSnippets(node, functionSnippets)
         },
+
+        ObjectProperty(path: NodePath<ObjectProperty>) {
+          if (t.isStringLiteral(path.node.key)) {
+            if (includeChinese(path.node.key.value)) {
+              hasTransformed = true
+              const translationKey = Collector.add(path.node.key.value, customizeKey)
+              path.replaceWith(
+                t.objectProperty(
+                  getReplaceValue(translationKey),
+                  path.node.value,
+                  true,
+                  path.node.shorthand,
+                  path.node.decorators
+                )
+              )
+            }
+          }
+        },
+
+        ObjectMethod(path: NodePath<ObjectMethod>) {
+          if (t.isStringLiteral(path.node.key)) {
+            if (includeChinese(path.node.key.value)) {
+              hasTransformed = true
+              const translationKey = Collector.add(path.node.key.value, customizeKey)
+              path.replaceWith(
+                t.objectMethod(
+                  path.node.kind,
+                  getReplaceValue(translationKey),
+                  path.node.params,
+                  path.node.body,
+                  true,
+                  path.node.generator,
+                  path.node.async
+                )
+              )
+            }
+          }
+        },
       }
     }
 


### PR DESCRIPTION
问题描述如下：
1、翻译词条的key和value，目前的处理混在一起，会导致i18n的用法（我对接的i18next，主要是字符串模板，双花括号的）与js语法（Vue template 双花括号执行代码）出现冲突，虽然原仓库针对的是i18n，但是我依然觉得key和value的处理分开会更好，因此抽提了相关修改做PR。
2、从@babel/core中引入types，解决t没有类型支持的问题，同时修复部分相关用法
3、对js代码的处理，考虑了中文作为对象Key的情况，解决特定情况下生成的代码出现语法错误的问题