### PR TITLE
fix: parse vue template as xml

### DIFF
--- a/packages/i18n-extract-cli/src/transformVue.ts
+++ b/packages/i18n-extract-cli/src/transformVue.ts
@@ -273,6 +273,7 @@ function handleTemplate(code: string, rule: Rule): string {
       recognizeSelfClosing: true,
       lowerCaseAttributeNames: false,
       decodeEntities: false,
+      xmlMode: true,
     }
   )
 


### PR DESCRIPTION
修改说明：在使用htmlparser2来解析template时，开启xmlMode，以实现更好的兼容性。

问题原因：下面这段template在原有情况下就会出问题

```html
<Title title="我是标题">
    <template v-slot:right>
        <icon title="关闭" />
   </template>
</Title>
```

Title对应是一个Vue组件，htmlparser2默认采用html标准来解析，会导致Title组件被解析为html的title元素，而根据标准，title元素的内容只能是字符串，因此会导致Title组件内的任何其他内容，都被htmlparser2当做字符串来处理。

Vue的template实际上非常灵活，相比于当做html，它更符合xml标准，建议开启htmlparser2的xmlMode以确保更好的兼容性。