### PR TITLE
fix: ensure file

### DIFF
--- a/packages/i18n-extract-cli/src/core.ts
+++ b/packages/i18n-extract-cli/src/core.ts
@@ -45,9 +45,11 @@ function isValidInput(input: string): boolean {
 
 function getSourceFilePaths(input: string, exclude: string[]): string[] {
   if (isValidInput(input)) {
-    return glob.sync(`${input}/**/*.{cjs,mjs,js,ts,tsx,jsx,vue}`, {
-      ignore: exclude,
-    })
+    return glob
+      .sync(`${input}/**/*.{cjs,mjs,js,ts,tsx,jsx,vue}`, {
+        ignore: exclude,
+      })
+      .filter((file) => fs.statSync(file).isFile())
   } else {
     return []
   }


### PR DESCRIPTION
当文件夹是以 .{ext}结尾时，会报错。
虽然，但是，还是确保一下都是文件吧~